### PR TITLE
Unset `textwidth` in `.vim/ftplugin/python.vim`

### DIFF
--- a/.vim/ftplugin/python.vim
+++ b/.vim/ftplugin/python.vim
@@ -4,7 +4,7 @@
 " the boundary
 let s:python_max_line_length = get(environ(), 'PYTHON_LINE_LENGTH', 79)
 
-let &l:textwidth = s:python_max_line_length
+let &l:textwidth = 0
 if exists('+colorcolumn')
     let &l:colorcolumn = s:python_max_line_length + 1
 endif


### PR DESCRIPTION
Python auto-formatting with ruff, etc. via vim-ale includes automatic line wrapping. This obsoletes the need for `textwidth` in vim for Python files.