### PR TITLE
Replace `jedi-vim` completion with Python LSP features via `ty`

### DIFF
--- a/.dotfiles/doc/vim.md
+++ b/.dotfiles/doc/vim.md
@@ -84,7 +84,7 @@ here.](http://michael.peopleofhonoronly.com/vim/)
 | `q` | Confirm and quit (`:conf q`) |
 | `Q` | Save and quit (`:wq`) |
 | `Ctrl+e` | Open CtrlP in find buffer mode (`:CtrlPBuffer`) |
-| `Ctrl+]` | Go to definition using [jedi-vim](https://github.com/davidhalter/jedi-vim) |
+| `Ctrl+]` | Go to definition using ALE LSP or ctags |
 
 ## Additional mappings
 
@@ -162,7 +162,11 @@ here.](http://michael.peopleofhonoronly.com/vim/)
 
 | Mapping | Meaning |
 | :-- | :-- |
-| `<Leader>d` | Toggle ALE |
+| `K` | Show language server hover info |
+| `<Leader>d` | Toggle ALE for current buffer |
+| `<Leader>a` | `:ALECodeAction` |
+| `<Leader>u` | `:ALEFindReferences`  |
+| `<Leader>n` | `:ALERename` |
 
 ### tcomment plugin mappings
 

--- a/.vim/ftplugin/python.vim
+++ b/.vim/ftplugin/python.vim
@@ -19,4 +19,7 @@ for s:manager in ['poetry', 'uv']
     endfor
 endfor
 
-nnoremap <buffer> <silent> <C-]> :call jedi#goto()<CR>
+let b:ale_completion_enabled = 1
+let b:completor_auto_trigger = 0
+
+call ALEAddLSPMappings()

--- a/.vimrc
+++ b/.vimrc
@@ -505,6 +505,7 @@ let g:ctrlp_user_command = {
 
 " Basic settings
 let g:ale_open_list = 0
+let g:ale_hover_cursor = 1
 let g:airline#extensions#ale#enabled = 1
 let g:ale_fix_on_save = 1
 let g:ale_echo_msg_format = '[%linter%] %s'
@@ -535,6 +536,20 @@ augroup ale_readonly
         \     let b:ale_fix_on_save = 0 |
         \ endif
 augroup END
+
+function! ALEAddLSPMappings() abort
+    nnoremap <buffer> <silent> <C-]> :ALEGoToDefinition<CR>
+    nnoremap <buffer> <silent> K :ALEHover<CR>
+    nnoremap <buffer> <silent> <leader>a :ALECodeAction<CR>
+    nnoremap <buffer> <silent> <leader>u :ALEFindReferences<CR>
+    nnoremap <buffer> <silent> <leader>n :ALERename<CR>
+endfunction
+
+" Show hover info in floating popup windows
+let g:ale_floating_preview = 1
+let g:ale_hover_to_floating_preview = 1
+let g:ale_detail_to_floating_preview = 1
+let g:ale_floating_window_border = ['│', '─', '╭', '╮', '╯', '╰', '│', '─']
 
 " }}}
 
@@ -603,9 +618,19 @@ let g:UltiSnipsExpandTrigger="<c-j>"
 
 " }}}
 
-" Autocompletion configuration (jedi-vim and completor) {{{
+" Python call signatures configuration (jedi-vim) {{{
 
+let g:jedi#completions_enabled = 0
+let g:jedi#documentation_command = ''
+let g:jedi#goto_command = ''
+let g:jedi#rename_command = ''
+let g:jedi#usages_command = ''
+let g:jedi#show_call_signatures = 1
 let g:jedi#show_call_signatures_delay = 100
+
+" }}}
+
+" Autocompletion configuration (completor) {{{
 
 let g:completor_auto_trigger = 1
 


### PR DESCRIPTION
`jedi-vim` itself is retained for call signatures