### PR TITLE
Remove bracketed paste mode support version conditional in `.vimrc`

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -57,12 +57,10 @@ set timeout timeoutlen=1000 ttimeoutlen=50
 set t_RV=
 
 " Enabled bracketed paste mode support
-if has("patch-8.0.0210")
-    let &t_BE = "\e[?2004h"
-    let &t_BD = "\e[?2004l"
-    let &t_PS = "\e[200~"
-    let &t_PE = "\e[201~"
-endif
+let &t_BE = "\e[?2004h"
+let &t_BD = "\e[?2004l"
+let &t_PS = "\e[200~"
+let &t_PE = "\e[201~"
 
 " Disable swap file fsync to prevent Vim from blocking when writing swap files
 set swapsync=


### PR DESCRIPTION
vim patch 8.0.0201 is from 2017 (9 years ago)